### PR TITLE
SWAT-2190: Skip prompts that use the default confirmation

### DIFF
--- a/main.js
+++ b/main.js
@@ -269,6 +269,8 @@ function apiify (promise) {
         [mark, message, choices] = arguments
       }
 
+      const skippable = !choices
+
       return apiify(wrap(mark, this.promise, () => {
         return new Promise(resolve => {
           process.stdin.addListener('data', handleInput)
@@ -283,8 +285,8 @@ function apiify (promise) {
           process.stdin.removeListener('data', handleInput)
           return data
         })
-      // For now, prompt steps are always required.
-      }, false))
+      // For now, non-default prompt steps are always required.
+      }, skippable))
     },
     done: function (msg) {
       promise.then(() => halt(0, msg)).catch(this.fail)


### PR DESCRIPTION
[SWAT-2190](https://bits.bazaarvoice.com/jira/browse/SWAT-2190)
## Goals

When using a [mark](https://github.com/bazaarvoice/unshackle#marks), prompts ahead of the mark are not skipped in case they are used to construct state used later in the script.

It is safe to assume that prompts that don't have custom options do not gather information, and can be skipped. This can reduce a lot of clutter and manual re-confirmation of steps before the target mark.

## Solution
<!--
  * Don't forget tests!
  * Include noteworthy risks.
-->

Simply check whether choices are supplied for prompt. If not, mark it skippable.

## How to Verify
<!-- Give step by step instructions. -->

Run a test script that looks something like this.

```javascript
unshackle
.start('You are starting an example release. Good luck.', 'important-step')
.prompt('Do you see this? You should not.')
.prompt('Do you see this? You should.', ['y'])
.prompt('important-step', 'Please confirm that you wish to continue')
.done()
```

<!-- Include a TODO checklist here if you are not done yet. -->
<!--
## To Do

- [x] Write tests.
- [ ] Update documentation.
-->
