### PR TITLE
Increase the max exec buffer to avoid crashes

### DIFF
--- a/main.js
+++ b/main.js
@@ -206,7 +206,8 @@ function apiify (promise) {
         body = () => {
           console.log(`$ ${command}`)
           return new Promise(resolve => {
-            const execution = cp.exec(command, (error, stdout) => {
+            // Use a very large (1 MB) buffer so large amounts of IO data do not crash.
+            const execution = cp.exec(command, {maxBuffer: 1024 * 1000}, (error, stdout) => {
               if (error) {
                 console.error(error.stack)
                 process.exit(1)


### PR DESCRIPTION
## Goals

This error can occur when large amounts of IO are output by a shell command:

```bash
Error: stdout maxBuffer exceeded
at Socket.onChildStdout (child_process.js:328:14)
at emitOne (events.js:121:20)
at Socket.emit (events.js:211:7)
at addChunk (_stream_readable.js:263:12)
at readableAddChunk (_stream_readable.js:246:13)
at Socket.Readable.push (_stream_readable.js:208:10)
at Pipe.onread (net.js:594:20)
```

## Solution

The "solution" here is to increase the IO buffer per the [exec options](https://stackoverflow.com/a/23429654/555642).

Note that doesn't remove the limit to prevent this problem from ever happening, it raises it to reduce the likelihood that it does.

<!--
  * Don't forget tests!
  * Include noteworthy risks.
-->

## How to Verify
<!-- Give step by step instructions. -->

One way to verify this is to run a very simple unshackle script like this:

```javascript
#!/usr/bin/env node

require('unshackle').run('cat myfile.txt')
```

Create myfile.txt with just under 1 MB of data in it.

<!-- Include a TODO checklist here if you are not done yet. -->
<!--
## To Do

- [x] Write tests.
- [ ] Update documentation.
-->
